### PR TITLE
feat(compat-node-v15)

### DIFF
--- a/.github/workflows/lerna_push_pr.yml
+++ b/.github/workflows/lerna_push_pr.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 12.x
+          node-version: 15.x
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Lint

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 12.x
+          node-version: 15.x
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 12.x
+          node-version: 15.x
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Lint

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For now, we are only exposing as libraries [co2-data](https://www.npmjs.com/pack
 
 ## Development - Getting started
 
-Project supports NodeJS v12.x. Support for v14 and above are on the way
+Project supports NodeJS >= v12.x
 
 1. Clone the project `git clone https://github.com/dvelasquez/carbon-tools.git`
 2. Run `yarn` to install the dev dependencies

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "posttest": "tap --coverage-report=html --coverage-report=cobertura"
   },
   "engines": {
-    "node": ">=12.0.0 <14.0.0"
+    "node": ">=12.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^15.1.0",

--- a/packages/co2-data/src/data/data-helpers.ts
+++ b/packages/co2-data/src/data/data-helpers.ts
@@ -1,0 +1,25 @@
+import { ElectricityMapDataResponse, ElectricityMapResult } from '../types';
+import { findKeysByCode } from '../country-names';
+
+export const getDataByCode = (dataResponse: ElectricityMapDataResponse, code?: string): ElectricityMapResult => {
+  const codesFound: string[] = findKeysByCode(code);
+  const result: ElectricityMapResult = {
+    code: code || 'ZZ',
+    codeList: [],
+    co2Intensities: [],
+    averageCo2Intensity: 0,
+  };
+  codesFound.forEach((code) => {
+    const countryData = dataResponse.data.countries[code];
+    if (countryData?.co2intensity) {
+      result.codeList.push(countryData.countryCode);
+      result.co2Intensities.push(countryData.co2intensity);
+    }
+  });
+  // Only reduce data from CountryCodes with data
+  if (result.co2Intensities.length > 0) {
+    result.averageCo2Intensity =
+      result.co2Intensities.reduce((a: number, b: number) => a + b) / result.co2Intensities.length;
+  }
+  return result;
+};

--- a/packages/co2-data/src/data/process-data.ts
+++ b/packages/co2-data/src/data/process-data.ts
@@ -1,31 +1,9 @@
 import fs from 'fs';
 import path from 'path';
 import { ESLint } from 'eslint';
-import { findKeysByCode, getCountries } from '../country-names';
+import { getCountries } from '../country-names';
 import { Co2Data, ElectricityMapDataResponse, ElectricityMapResult, ElectricityMapResultAveraged } from '../types';
-
-export const getDataByCode = (dataResponse: ElectricityMapDataResponse, code?: string): ElectricityMapResult => {
-  const codesFound: string[] = findKeysByCode(code);
-  const result: ElectricityMapResult = {
-    code: code || 'ZZ',
-    codeList: [],
-    co2Intensities: [],
-    averageCo2Intensity: 0,
-  };
-  codesFound.forEach((code) => {
-    const countryData = dataResponse.data.countries[code];
-    if (countryData?.co2intensity) {
-      result.codeList.push(countryData.countryCode);
-      result.co2Intensities.push(countryData.co2intensity);
-    }
-  });
-  // Only reduce data from CountryCodes with data
-  if (result.co2Intensities.length > 0) {
-    result.averageCo2Intensity =
-      result.co2Intensities.reduce((a: number, b: number) => a + b) / result.co2Intensities.length;
-  }
-  return result;
-};
+import { getDataByCode } from './data-helpers';
 
 (async () => {
   const fsPromise = fs.promises;

--- a/packages/co2-data/src/index.test.ts
+++ b/packages/co2-data/src/index.test.ts
@@ -1,7 +1,7 @@
 import Tap from 'tap';
 // @ts-ignore
 import electricityMapData from './data/json/13-9-2020--12.json';
-import { getDataByCode } from './data/process-data';
+import { getDataByCode } from './data/data-helpers';
 
 Tap.test('should get the data based in an ISO code', (t) => {
   const clResult = getDataByCode(electricityMapData, 'CL');


### PR DESCRIPTION
This PR adds compatibility with Node V15 by moving the function `getDataByCode` to their own file. This was needed because the function was in a complicated file called `process-data` which imported a json file that can't be properly resolved from the tests running in the root of the monorepo.

References #8 