### PR TITLE
chore: reduce Renovate noise with monthly grouped automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,5 @@
 {
-  "extends": ["config:recommended"],
-  "schedule": ["after 10pm on sunday", "before 5am on sunday"],
+  "extends": ["config:recommended", "group:all", "schedule:monthly"],
   "minimumReleaseAge": "3 days",
-  "packageRules": [
-    {
-      "matchDepTypes": ["devDependencies"],
-      "automerge": true
-    }
-  ]
+  "automerge": true
 }


### PR DESCRIPTION
## Summary
- Switch Renovate to a single monthly PR that groups all dependency updates
- Enable automerge for those updates once checks pass
- Drop the weekly schedule and per-devDependency automerge rules in favor of `group:all` + `schedule:monthly`

## Test plan
- [ ] Confirm Renovate config validates (e.g. via Renovate dashboard / config validator)
- [ ] After merge, verify the next Renovate run opens one grouped PR instead of many
- [ ] Confirm automerge triggers when CI is green


Made with [Cursor](https://cursor.com)